### PR TITLE
Adjust linux64 link order and chasm invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,26 +5,19 @@
 #
 # - This really should compile object files into a separate intermediate
 #   directory so that we can speed up compilation.
-# - The speed of compilation of fast enough that, for now, this doesn't
-#   really matter.
+# - We ought to check to see if CHASM_HOME is set rather than hardcoding
+#   it ourselves.
 #
 # TO BUILD A SHARED LIBRARY!
 # gcc -g -fPIC -Wall -Werror -Wextra -pedantic *.c -shared -o liball.so
 #
 
-
 # Path to current Makefile. Uses _HACK_ to chop off last slash.
 WRAW=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 WHERE=$(WRAW:%/=%)
 
-
 # Get the name of the current operating system.
 UNAME=$(shell uname)
-
-
-# Hard coded path to the assembler I am using for this VM.
-CHASM_HOME=python ~/Programming/repos/chasm/chasm.py
-
 
 # Project specific file/compiler info.
 CC=gcc
@@ -32,11 +25,9 @@ STD=c99
 EXT=c
 HDR=h
 
-
 # WARN: Path is relative to Makefile location (top level)!
 BIN_DIR=$(WHERE)/bin
 OBJ_DIR=$(WHERE)/obj
-
 
 # Info fields for the VM library.
 LIB_NAME=libcsm.so
@@ -61,7 +52,6 @@ LIB_SRC_DIR=src
 LIB_SRC=$(wildcard $(LIB_SRC_DIR)/*.$(EXT))
 LIB_BIN=
 
-
 # Calling these unit, these are "single source file binaries".
 U_PREFIX=csm
 U_LIB=csm
@@ -72,7 +62,7 @@ U_GLIB=$(U_LIB:%=-l%)
 U_GLIBPATH=$(U_LIBPATH:%=-L%)
 U_GLINKPATH=$(U_LIBPATH:%=-Wl,-rpath=%)
 U_GINC=$(U_INC:%=-I%)
-U_GLOB=$(U_GLIB) $(U_GLIBPATH) $(U_GLINKPATH) $(U_GINC)
+U_GLOB=$(U_GLIBPATH) $(U_GLIB) $(U_GLINKPATH) $(U_GINC) $(U_GLIB)
 
 U_FOPT=
 U_FWARN=-Wall -Werror -Wextra -pedantic
@@ -90,10 +80,8 @@ TEST_DIR=test
 TEST_SRC=$(wildcard $(TEST_DIR)/*.chasm)
 TEST_DUMP=dump
 
-
 .PHONY: all
 all: check_chasm init libcsm unit test
-
 
 .PHONY: check_chasm
 check_chasm:
@@ -101,42 +89,38 @@ ifeq ($(CHASM_HOME),)
 	$(error The location of CHASM_HOME must be set to continue)
 endif
 
-
+# TODO: Make this take advantage of the Makefile dependency graph.
 .PHONY: libcsm
 libcsm: init
-	@echo ">> Building VM shared library..."
+	@echo "-- Building VM shared library..."
 	$(CC) -o $(BIN_DIR)/$(LIB_NAME) \
 		$(LIB_SRC) \
 		$(LIB_CFLAGS) $(LIB_LDFLAGS) $(LIB_LIB)
 
-
 .PHONY: unit
 unit: libcsm $(U_BIN)
 
-
 $(U_BIN): $(BIN_DIR)/$(U_PREFIX)-% : $(U_SRC_DIR)/%.$(EXT)
-	@echo ">> Building unit: " $@
-	$(CC) -o $@ $(U_CFLAGS) $(U_LDFLAGS) $<
+	@echo "-- Building unit: " $@
+	$(CC) -o $@ $< $(U_CFLAGS) $(U_LDFLAGS)
 
 .PHONY: test
 test: $(TEST_SRC)
-	@echo ">> Building VM test files..."
-	$(CHASM_HOME) $(TEST_SRC) -or:$(TEST_DUMP)
+	@echo "-- Building VM test files..."
+	python3 $(CHASM_HOME)/chasm.py $(TEST_SRC) -or:$(TEST_DUMP)
 	@echo "DONE!"
 
 .PHONY: init
 init:
 	@mkdir -p $(BIN_DIR)
 
-
 .PHONY: clean
 clean:
 	@test -n $(BIN_DIR) && rm -rf $(BIN_DIR)/* \
 		rmdir $(BIN_DIR)
 
-
 # Won't ever fire, at this rate.
 %.chasm:
-	@echo ">> Compiling: " $@
-	$(CHASM_HOME) $@ -or:$(TDUMP) -dsegments
+	@echo "-- Compiling: " $@
+	python3 $(CHASM_HOME)/chasm.py $@ -or:$(TDUMP) -dsegments
 

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ $(U_BIN): $(BIN_DIR)/$(U_PREFIX)-% : $(U_SRC_DIR)/%.$(EXT)
 
 .PHONY: test
 test: $(TEST_SRC)
+	@mkdir -p $(TEST_DUMP)
 	@echo "-- Building VM test files..."
 	python3 $(CHASM_HOME)/chasm.py $(TEST_SRC) -or:$(TEST_DUMP)
 	@echo "DONE!"


### PR DESCRIPTION
This PR cleans up the project `Makefile` and fixes some issues that were preventing me from compiling on a fresh `linux64` installation.

The `linux64` linker is sensitive to the order in which libraries are passed via the command line. This was preventing driver programs that referenced the VM shared library from linking against it. To fix it, we link against the VM last (in other words, list the driver source file first).

We also adjust the `chasm` invocation to be a proper call to `python3`, and make sure to create the `dump` directory before compiling any tests.